### PR TITLE
008 department service register with eureka server

### DIFF
--- a/backend/department-service/pom.xml
+++ b/backend/department-service/pom.xml
@@ -9,10 +9,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
+    </properties>
+
     <artifactId>department-service</artifactId>
 
-    <properties>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -23,7 +25,14 @@
             <artifactId>postgresql</artifactId>
             <version>42.7.3</version> <!-- Specify the version you want to use -->
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
     </dependencies>
+
+
     <repositories>
         <repository>
             <id>maven_central</id>

--- a/backend/department-service/src/main/resources/application.yml
+++ b/backend/department-service/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: service-registry
+    name: department-service
   springdoc:
     api-docs:
       path: /api-docs
@@ -15,6 +15,13 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
+    instance:
+      preferIpAddress: true
 
 server:
   port: 8082

--- a/backend/service-registry/src/main/resources/application.yml
+++ b/backend/service-registry/src/main/resources/application.yml
@@ -1,16 +1,10 @@
 spring:
   application:
     name: service-registry
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/eureka/
-    fetch-registry: false
-  register:
-    with:
-      eureka: false
-
-
 server:
   port: 8761
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
 

--- a/data/eureka-services/Nota.txt
+++ b/data/eureka-services/Nota.txt
@@ -1,0 +1,5 @@
+Update on using Spring Boot 3 Version
+In the next lecture, make the below small change to support Spring Boot 3 and Spring Cloud 2022.0.0:
+
+-Don’t annotate an entry-point EmployeeServiceApplication class with
+@EnableEurekaClient - This annotation was removed in spring cloud 2022.0.0 and provided auto-configuration.

--- a/data/eureka-services/Nota.txt
+++ b/data/eureka-services/Nota.txt
@@ -2,4 +2,4 @@ Update on using Spring Boot 3 Version
 In the next lecture, make the below small change to support Spring Boot 3 and Spring Cloud 2022.0.0:
 
 -Don’t annotate an entry-point EmployeeServiceApplication class with
-@EnableEurekaClient - This annotation was removed in spring cloud 2022.0.0 and provided auto-configuration.
+@EnableEurekaClient - This annotation was removed in spring cloud 2022.0.0 and provided autoconfiguration.

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
         <mockito.version>5.11.0</mockito.version>
     </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -82,7 +84,7 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.9.0</version>
+            <version>5.11.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
@@ -106,6 +108,8 @@
             <version>${mockito.version}</version>
         </dependency>
     </dependencies>
+
+
 
     <dependencyManagement>
         <dependencies>
@@ -147,6 +151,14 @@
                 <groupId>code.with.vanilson</groupId>
                 <artifactId>common</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-parent</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Update on using Spring Boot 3 Version
In the next lecture, make the below small change to support Spring Boot 3 and Spring Cloud 2022.0.0:

-Don’t annotate an entry-point EmployeeServiceApplication class with
@EnableEurekaClient - This annotation was removed in spring cloud 2022.0.0 and provided autoconfiguration.